### PR TITLE
Revert "Added Phan to list of CC engines"

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -13,11 +13,6 @@ engines:
       file_extensions:
         - php
       rulesets: "phpmd.xml"
-plugins:
-  phan:
-    enabled: true
-    config:
-      file_extensions: "php"
 ratings:
   paths:
   - "**.inc"


### PR DESCRIPTION
Reverts Dhii/container-helper-base#19.

Build erred with the following output:

```
codeclimate validate-config
ERROR: only use one of 'engines', 'plugins'
WARNING: missing 'version' key. Please add `version: "2"`
WARNING: 'engines' has been deprecated, please use 'plugins' instead
WARNING: 'exclude_paths' has been deprecated, please use 'exclude_patterns' instead
WARNING: 'ratings' has been deprecated, and will not be used
```

This suggests a need to bring CC config up to standard, and use new format.